### PR TITLE
Ship PUR-100: hero 2-CTA (Resume primary, Send-a-message secondary)

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,20 +1,25 @@
-import React from "react";
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import { InfiniteMovingLogos } from "./ui/infinite-moving-logos";
 import { HoverBorderGradient } from "./ui/hover-border-gradient";
 import { AnimatedPin } from "./ui/animated-pin";
+import { Modal } from "./ui/modal";
+import { ContactForm } from "./ui/contact-form";
+import { BorderButton } from "./ui/border-button";
 import HeroVideo from "../assets/hero-video.mp4";
 import { BackgroundBeams } from "./ui/background-beams.tsx";
 
 export default function Hero() {
+  const [isContactModalOpen, setIsContactModalOpen] = useState(false);
   return (
     <>
-      <div className="xs:h-[150vh] h-[105vh] md:h-screen w-full relative flex flex-col items-center justify-center antialiased overflow-hidden">
+      <div className="xs:h-[150vh] h-[110vh] md:h-screen w-full relative flex flex-col items-center justify-center antialiased overflow-hidden">
         {/* Background with enhanced opacity for mobile */}
         <div className="absolute inset-0 w-full h-full bg-neutral-950">
           <BackgroundBeams className="opacity-75 sm:opacity-85 md:opacity-90" />
         </div>
         
-        <div className="max-w-6xl mx-auto px-4 relative z-10 py-12 md:py-0">
+        <div className="max-w-6xl mx-auto px-4 relative z-10 py-12 md:py-0 pb-48 md:pb-0">
           <div className="relative z-10 w-[140px] h-[140px] md:w-[200px] md:h-[200px] lg:w-[240px] lg:h-[240px] mx-auto mb-6 md:mb-8">
             <AnimatedPin>
               <HoverBorderGradient>
@@ -39,13 +44,27 @@ export default function Hero() {
             Senior Product Designer
           </p>
           <p className="text-neutral-300 max-w-2xl mx-auto mt-6 text-sm sm:text-base md:text-lg text-center relative z-10 leading-relaxed">
-            I design B2B platforms, fintech tools, and operating systems for ops teams. Ten years of work across supply chains, payments, logistics, and gaming. Case studies below.
+            Platforms, fintech tools, and operating systems for ops teams: 10 years of shipping work across supply chains, payments, logistics, and gaming.
           </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4 mt-6 sm:mt-8 relative z-10">
+            <Link to="/about">
+              <BorderButton variant="primary">Resume</BorderButton>
+            </Link>
+            <BorderButton
+              variant="ghost"
+              onClick={() => setIsContactModalOpen(true)}
+            >
+              Send a message
+            </BorderButton>
+          </div>
         </div>
         <div className="absolute bottom-4 md:bottom-5 w-full z-10">
           <InfiniteMovingLogos />
         </div>
       </div>
+      <Modal isOpen={isContactModalOpen} onClose={() => setIsContactModalOpen(false)}>
+        <ContactForm onClose={() => setIsContactModalOpen(false)} />
+      </Modal>
     </>
   );
 }

--- a/src/components/ui/border-button.jsx
+++ b/src/components/ui/border-button.jsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { cn } from "../../utils/cn";
 
-export const BorderButton = ({ children, className, ...props }) => {
+export const BorderButton = ({ children, className, variant = "primary", ...props }) => {
+  const isGhost = variant === "ghost";
   return (
     <button
       className={cn(
@@ -10,8 +11,19 @@ export const BorderButton = ({ children, className, ...props }) => {
       )}
       {...props}
     >
-      <span className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#E2CBFF_0%,#393BB2_50%,#E2CBFF_100%)]" />
-      <span className="inline-flex h-full w-full cursor-pointer items-center justify-center rounded-full bg-black/80 px-4 py-1 text-sm font-medium text-white backdrop-blur-3xl">
+      {isGhost ? (
+        <span className="absolute inset-0 rounded-full border border-neutral-700" />
+      ) : (
+        <span className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#E2CBFF_0%,#393BB2_50%,#E2CBFF_100%)]" />
+      )}
+      <span
+        className={cn(
+          "inline-flex h-full w-full cursor-pointer items-center justify-center rounded-full px-4 py-1 text-sm font-medium backdrop-blur-3xl",
+          isGhost
+            ? "bg-transparent text-neutral-300 hover:text-white hover:bg-neutral-900/40"
+            : "bg-black/80 text-white"
+        )}
+      >
         {children}
       </span>
     </button>


### PR DESCRIPTION
## Summary
- Hero gains 2-CTA row per [PUR-102](/PUR/issues/PUR-102) James verdict: solid **Resume** (primary, links to /about) + ghost **Send a message** (secondary, opens existing ContactForm modal).
- `BorderButton` adds `variant="ghost"` (outline-only, transparent fill, neutral-300 text → white on hover).
- Mobile stacks (primary on top), desktop row left→right; gap-3/sm:gap-4.
- Mobile hero `h-[110vh]` + inner `pb-48` to clear logo strip after CTA stack.

## Test plan
- [x] Desktop 1440 — Resume solid + Send-a-message ghost, both visible weight delta
- [x] Mobile 390 — stack, primary on top, no overlap with caption / logo strip
- [ ] iPhone SE 375 — verify post-merge (xs height tightens further)
- [ ] Modal opens on Send-a-message click (verified locally)
- [ ] Resume routes to /about (verified locally)

Resolves [PUR-100](/PUR/issues/PUR-100) round-2; carries [PUR-102](/PUR/issues/PUR-102) verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)